### PR TITLE
Fix newlines in scripts

### DIFF
--- a/script/test
+++ b/script/test
@@ -24,7 +24,7 @@ if [ $? -eq 1 ]; then
 fi
 
 if [ ! $SKIP_CLJS ]; then
-    echo "\n=== Running cljs tests"
+    echo -e "\n=== Running cljs tests"
     mkdir -p cljs-test-runner-out/gen
     clojure -A:test:test-cljs \
             -d src -r "$regex" \

--- a/script/test-one
+++ b/script/test-one
@@ -32,7 +32,7 @@ if [ $? -eq 1 ]; then
 fi
 
 if [ ! $SKIP_CLJS ]; then
-    echo "\n=== Running cljs test $1"
+    echo -e "\n=== Running cljs test $1"
     mkdir -p cljs-test-runner-out/gen
     clojure -A:test:test-cljs \
             -d src \


### PR DESCRIPTION
`echo` can interpret escape sequences if you pass it the `-e` flag.