### PR TITLE
Added aoc.y2018.d18.dfuenzalida

### DIFF
--- a/src/aoc/y2018/d18/dfuenzalida.cljc
+++ b/src/aoc/y2018/d18/dfuenzalida.cljc
@@ -1,0 +1,96 @@
+(ns aoc.y2018.d18.dfuenzalida
+  (:refer-clojure :exclude [read-string format])
+  (:require
+   [aoc.utils :as u :refer [deftest read-string format]]
+   [aoc.y2018.d18.data :refer [input answer-1 answer-2]]
+   [clojure.string :as s]
+   [clojure.test :as t :refer [is testing]]))
+
+(defn char-at [^String s ^Integer i]
+  (.substring s i (inc i)))
+
+(defn adjacents [terrain ^Integer x ^Integer y]
+  (merge
+   {"." 0 "|" 0 "#" 0} ;; defaults
+   (let [width  (count (first terrain))
+         height (count terrain)]
+     (frequencies
+      (for [dx (range -1 2)
+            dy (range -1 2)
+            :let [x2 (+ x dx)
+                  y2 (+ y dy)]
+            :when (and (not= [0 0] [dx dy])
+                       (<= 0 x2) (< x2 width)
+                       (<= 0 y2) (< y2 width))]
+        (let [c (char-at (nth terrain y2) x2)]
+          c))))))
+
+(defn iter-acre [terrain ^Integer x ^Integer y]
+  (let [acre (char-at (nth terrain y) x)
+        adjs (adjacents terrain x y)]
+    (cond
+      (= "." acre) (let [trees (get adjs "|")]
+                     (if (>= trees 3) "|" "."))
+
+      (= "|" acre) (let [lumbs (get adjs "#")]
+                     (if (>= lumbs 3) "#" "|"))
+
+      (= "#" acre) (let [lumbs (get adjs "#")
+                         trees (get adjs "|")]
+                     (if (and (pos? lumbs) (pos? trees)) "#" "."))
+
+      :else "?")))
+
+(defn step-terrain [terrain]
+  (into
+   []
+   (let [width  (count (first terrain))
+         height (count terrain)]
+     (for [y (range height)]
+       (apply str
+              (for [x (range width)]
+                (iter-acre terrain x y)))))))
+
+(defn iter-terrain [terrain]
+  (iterate step-terrain terrain))
+
+(defn solve-1 []
+  (let [input   (s/split-lines input)
+        iters   10
+        terrain (apply str (last (take (inc iters) (iter-terrain input))))
+        freqs   (frequencies terrain)
+        trees   (get freqs \| 0)
+        lumbs   (get freqs \# 0)]
+    (* trees lumbs)))
+
+(defn find-fixed-terrain [terrain-iterator]
+  (let [tuples (map-indexed vector (take 1000 terrain-iterator))]
+    (loop [tuples tuples, seen {}]
+      (let [[i terr] (first tuples)]
+        (if (seen terr)
+          [i (seen terr)] ;; [current-index index-of-previously-seen-terrain]
+          (recur (rest tuples) (assoc seen terr i)))))))
+
+(defn solve-2 []
+  (let [input  (s/split-lines input)
+        terr-i (iter-terrain input)
+        [b a]  (find-fixed-terrain terr-i)
+        period (- b a)
+        index  (+ a (mod (- 1000000000 a) period))
+        terr   (first (drop index terr-i))
+        freqs  (frequencies (apply str terr))]
+    (* (get freqs \| 0) (get freqs \# 0))))
+
+(deftest part-1
+  (is (= (str answer-1)
+         (str (solve-1)))))
+
+(deftest part-2
+  (is (= (str answer-2)
+         (str (solve-2)))))
+
+;;;; Scratch
+
+(comment
+  (t/run-tests)
+)

--- a/src/aoc/y2018/d18/dfuenzalida.cljc
+++ b/src/aoc/y2018/d18/dfuenzalida.cljc
@@ -6,10 +6,10 @@
    [clojure.string :as s]
    [clojure.test :as t :refer [is testing]]))
 
-(defn char-at [^String s ^Integer i]
+(defn char-at [^String s ^long i]
   (.substring s i (inc i)))
 
-(defn adjacents [terrain ^Integer x ^Integer y]
+(defn adjacents [terrain ^long x ^long y]
   (merge
    {"." 0 "|" 0 "#" 0} ;; defaults
    (let [width  (count (first terrain))
@@ -25,7 +25,7 @@
         (let [c (char-at (nth terrain y2) x2)]
           c))))))
 
-(defn iter-acre [terrain ^Integer x ^Integer y]
+(defn iter-acre [terrain ^long x ^long y]
   (let [acre (char-at (nth terrain y) x)
         adjs (adjacents terrain x y)]
     (cond


### PR DESCRIPTION
Tested with the following (emits a few warnings for the CLJS version because of the type hints):

```
$ ./script/test-one aoc.y2018.d18.dfuenzalida
=== Running clojure test aoc.y2018.d18.dfuenzalida  

Running tests in #{"src"}

Testing aoc.y2018.d18.dfuenzalida
part-2 took 8606 msecs
part-1 took 152 msecs

Ran 2 tests containing 2 assertions.
0 failures, 0 errors.

=== Running cljs test aoc.y2018.d18.dfuenzalida  
WARNING: cljs.core/+, all arguments must be numbers, got [Integer number] instead at line 10 /home/denis/Proyectos/advent-of-cljc/src/aoc/y2018/d18/dfuenzalida.cljc
WARNING: cljs.core/+, all arguments must be numbers, got [Integer #{any clj-nil}] instead at line 20 /home/denis/Proyectos/advent-of-cljc/src/aoc/y2018/d18/dfuenzalida.cljc
WARNING: cljs.core/+, all arguments must be numbers, got [Integer any] instead at line 21 /home/denis/Proyectos/advent-of-cljc/src/aoc/y2018/d18/dfuenzalida.cljc
WARNING: cljs.core/+, all arguments must be numbers, got [Integer #{any clj-nil}] instead at line 20 /home/denis/Proyectos/advent-of-cljc/src/aoc/y2018/d18/dfuenzalida.cljc
WARNING: cljs.core/+, all arguments must be numbers, got [Integer #{any clj-nil}] instead at line 21 /home/denis/Proyectos/advent-of-cljc/src/aoc/y2018/d18/dfuenzalida.cljc

Testing aoc.y2018.d18.dfuenzalida
part-1 took 854 msecs
part-2 took 28647 msecs

Ran 2 tests containing 2 assertions.
0 failures, 0 errors.
```