### PR TITLE
Added solutions for 2017, days 01 to 10

### DIFF
--- a/src/aoc/y2017/d01/dfuenzalida.cljc
+++ b/src/aoc/y2017/d01/dfuenzalida.cljc
@@ -1,0 +1,35 @@
+(ns aoc.y2017.d01.dfuenzalida
+  (:refer-clojure :exclude [read-string format])
+  (:require
+   [aoc.utils :as u :refer [deftest read-string format]]
+   [aoc.y2017.d01.data :refer [input answer-1 answer-2]]
+   [clojure.test :as t :refer [is testing]]))
+
+(defn solve-1 []
+  (let [s            input
+        s2           (take (count s) (drop 1 (cycle s)))
+        matching     (filter some? (map (fn [x y] (#{x} y)) s s2))
+        digit-to-int (into {} (map-indexed (fn [i c] [c i]) "0123456789"))]
+    (reduce + (map digit-to-int matching))))
+
+(defn solve-2 []
+  (let [s            input
+        half         (int (/ (count s) 2))
+        s2           (take (count s) (drop half (cycle s)))
+        matching     (filter some? (map (fn [x y] (#{x} y)) s s2))
+        digit-to-int (into {} (map-indexed (fn [i c] [c i]) "0123456789"))]
+    (reduce + (map digit-to-int matching))))
+
+(deftest part-1
+  (is (= (str answer-1)
+         (str (solve-1)))))
+
+(deftest part-2
+  (is (= (str answer-2)
+         (str (solve-2)))))
+
+;;;; Scratch
+
+(comment
+  (t/run-tests)
+)

--- a/src/aoc/y2017/d02/dfuenzalida.cljc
+++ b/src/aoc/y2017/d02/dfuenzalida.cljc
@@ -1,0 +1,45 @@
+(ns aoc.y2017.d02.dfuenzalida
+  (:refer-clojure :exclude [read-string format])
+  (:require
+   [aoc.utils :as u :refer [deftest read-string format]]
+   [aoc.y2017.d02.data :refer [input answer-1 answer-2]]
+   [clojure.string :as s]
+   [clojure.test :as t :refer [is testing]]))
+
+(defn read-input []
+  (->> (s/split-lines input)
+       (map #(str "[" % "]"))
+       (mapv read-string)))
+
+(defn solve-1 []
+  (let [seqs (read-input)]
+    (reduce +
+            (map - (map #(apply max %) seqs)
+                   (map #(apply min %) seqs)))))
+
+(defn check-row [xs]
+  (first (for [a (range (count xs))
+               b (range (count xs))
+               :let [xa (xs a)
+                     xb (xs b)]
+               :when (and (not= a b)            ;; a and b are not the same index
+                          (zero? (rem xa xb)))] ;; numbers divide evenly
+           (int (/ xa xb)))))
+
+(defn solve-2 []
+  (let [seqs (read-input)]
+    (reduce + (map check-row seqs))))
+
+(deftest part-1
+  (is (= (str answer-1)
+         (str (solve-1)))))
+
+(deftest part-2
+  (is (= (str answer-2)
+         (str (solve-2)))))
+
+;;;; Scratch
+
+(comment
+  (t/run-tests)
+)

--- a/src/aoc/y2017/d03/dfuenzalida.cljc
+++ b/src/aoc/y2017/d03/dfuenzalida.cljc
@@ -1,0 +1,72 @@
+(ns aoc.y2017.d03.dfuenzalida
+  (:refer-clojure :exclude [read-string format])
+  (:require
+   [aoc.utils :as u :refer [deftest read-string format]]
+   [aoc.y2017.d03.data :refer [input answer-1 answer-2]]
+   [clojure.test :as t :refer [is testing]]))
+
+(defn moves [n]
+  (concat (repeat n (if (odd? n) :right :left))
+          (repeat n (if (odd? n) :up :down))))
+
+(defn path [n]
+  (->> (range)
+       (drop 1)
+       (map moves)
+       (apply concat)
+       (take (dec n))))
+
+(def shifts {:left [-1 0] :right [1  0]
+             :up   [ 0 1] :down  [0 -1]})
+
+(defn distance [n]
+  (let [steps (map shifts (path n))]
+    (+
+     (Math/abs (reduce + (map first steps)))
+     (Math/abs (reduce + (map second steps))))))
+
+(defn solve-1 []
+  (distance input))
+
+(def all-moves ;; lazy-seq of all the moves from the center of the grid
+  (->> (range)
+       (drop 1)
+       (map moves)
+       (apply concat)))
+
+(defn coords-plus [[a b] [c d]]
+  [(+ a c) (+ b d)])
+
+(defn compute-grid [grid [x y]]
+  (reduce +
+          (for [i [-1 0 1]
+                j [-1 0 1]
+                :when (and (not= 0 i j)
+                           (some? (grid [(+ x i) (+ y j)])))]
+            (grid [(+ x i) (+ y j)]))))
+
+(defn fill-grid [grid [x y] moves-seq limit]
+  (let [curr (compute-grid grid [x y])]
+    (if (>= curr limit)
+      curr
+      (let [new-grid  (assoc grid [x y] curr)
+            curr-move (first moves-seq)
+            new-coord (coords-plus [x y] (shifts curr-move))]
+        (fill-grid new-grid new-coord (rest moves-seq) limit)))))
+
+(defn solve-2 []
+  (fill-grid {[0 0] 1} [1 0] (drop 1 all-moves) input))
+
+(deftest part-1
+  (is (= (str answer-1)
+         (str (solve-1)))))
+
+(deftest part-2
+  (is (= (str answer-2)
+         (str (solve-2)))))
+
+;;;; Scratch
+
+(comment
+  (t/run-tests)
+)

--- a/src/aoc/y2017/d04/dfuenzalida.cljc
+++ b/src/aoc/y2017/d04/dfuenzalida.cljc
@@ -1,0 +1,42 @@
+(ns aoc.y2017.d04.dfuenzalida
+  (:refer-clojure :exclude [read-string format])
+  (:require
+   [aoc.utils :as u :refer [deftest read-string format]]
+   [aoc.y2017.d04.data :refer [input answer-1 answer-2]]
+   [clojure.string :as s]
+   [clojure.test :as t :refer [is testing]]))
+
+(defn valid? [s]
+  (->> (s/split s #" ")
+       frequencies
+       vals
+       (into #{})
+       (= #{1})))
+
+(defn solve-1 []
+  (->> input s/split-lines (filter valid?) count))
+
+(defn valid2? [s]
+  (->> (s/split s #" ")
+       (map frequencies)
+       frequencies
+       vals
+       (into #{})
+       (= #{1})))
+
+(defn solve-2 []
+  (->> input s/split-lines (filter valid2?) count))
+
+(deftest part-1
+  (is (= (str answer-1)
+         (str (solve-1)))))
+
+(deftest part-2
+  (is (= (str answer-2)
+         (str (solve-2)))))
+
+;;;; Scratch
+
+(comment
+  (t/run-tests)
+)

--- a/src/aoc/y2017/d05/dfuenzalida.cljc
+++ b/src/aoc/y2017/d05/dfuenzalida.cljc
@@ -1,0 +1,48 @@
+(ns aoc.y2017.d05.dfuenzalida
+  (:refer-clojure :exclude [read-string format])
+  (:require
+   [aoc.utils :as u :refer [deftest read-string format]]
+   [aoc.y2017.d05.data :refer [input answer-1 answer-2]]
+   [clojure.test :as t :refer [is testing]]))
+
+(defn iter-offsets [pos offsets steps]
+  (if (>= pos (count offsets))
+    steps ;; we escaped!
+    (let [curr    (offsets pos)
+          new-pos (+ pos curr)]
+      (recur new-pos
+             (assoc-in offsets [pos] (inc curr))
+             (inc steps)))))
+
+(defn read-input []
+  (read-string (str "[" input "]")))
+
+(defn solve-1 []
+  (iter-offsets 0 (read-input) 0))
+
+(defn iter-offsets2 [pos offsets steps]
+  (if (>= pos (count offsets))
+    steps ;; we escaped!
+    (let [curr    (offsets pos)
+          new-pos (+ pos curr)
+          change  (if (>= curr 3) dec inc)]
+      (recur new-pos
+             (assoc-in offsets [pos] (change curr))
+             (inc steps)))))
+
+(defn solve-2 []
+  (iter-offsets2 0 (read-input) 0))
+
+(deftest part-1
+  (is (= (str answer-1)
+         (str (solve-1)))))
+
+(deftest part-2
+  (is (= (str answer-2)
+         (str (solve-2)))))
+
+;;;; Scratch
+
+(comment
+  (t/run-tests)
+  )

--- a/src/aoc/y2017/d06/dfuenzalida.cljc
+++ b/src/aoc/y2017/d06/dfuenzalida.cljc
@@ -1,0 +1,65 @@
+(ns aoc.y2017.d06.dfuenzalida
+  (:refer-clojure :exclude [read-string format])
+  (:require
+   [aoc.utils :as u :refer [deftest read-string format]]
+   [aoc.y2017.d06.data :refer [input answer-1 answer-2]]
+   [clojure.test :as t :refer [is testing]]))
+
+(defn distribute
+  [xs idx cnt]
+  (let [idx (mod idx (count xs))]
+    (if (pos? cnt)
+      (recur
+       (assoc-in xs [idx] (inc (xs idx)))
+       (inc idx)
+       (dec cnt))
+      xs)))
+
+(defn reallocate
+  [xs prevs i] ;; banks as a vector, previous vectors, iterations
+  (if (prevs xs)
+    [(count prevs) i]
+    (let [max-val (apply max xs)
+          max-idx (first (first (filter
+                                 (comp #{max-val} second)
+                                 (map-indexed vector xs))))
+          new-xs  (distribute (assoc-in xs [max-idx] 0)
+                              (inc max-idx)
+                              max-val)]
+      (recur new-xs (into prevs [xs]) (inc i)))))
+
+(defn read-input []
+  (read-string (str "[" input "]")))
+
+(defn solve-1 []
+  (first (reallocate (read-input) #{} 0)))
+
+(defn reallocate2
+  [xs prevs i] ;; banks as a vector, previous vectors map, iterations
+  (if (prevs xs)
+    (- i (prevs xs))
+    (let [max-val (apply max xs)
+          max-idx (first (first (filter
+                                 (comp #{max-val} second)
+                                 (map-indexed vector xs))))
+          new-xs  (distribute (assoc-in xs [max-idx] 0)
+                              (inc max-idx)
+                              max-val)]
+      (recur new-xs (into prevs {xs i}) (inc i)))))
+
+(defn solve-2 []
+  (reallocate2 (read-input) {} 0))
+
+(deftest part-1
+  (is (= (str answer-1)
+         (str (solve-1)))))
+
+(deftest part-2
+  (is (= (str answer-2)
+         (str (solve-2)))))
+
+;;;; Scratch
+
+(comment
+  (t/run-tests)
+)

--- a/src/aoc/y2017/d07/dfuenzalida.cljc
+++ b/src/aoc/y2017/d07/dfuenzalida.cljc
@@ -68,30 +68,21 @@
                          first second first first)]
       (unbalanced weight-map children-map unb-child))))
 
-(def large-weight-map
-  (load-map (read-input) (juxt first second)))
-
-(def large-children-map
-  (load-map (read-input) (juxt first last)))
-
-(def large-unbalanced
-  (unbalanced large-weight-map large-children-map (root-name)))
-
-(def large-parent-map
-  (lines-to-children-map (read-input)))
-
-(def large-desired-tree-weight
-  (->> large-unbalanced
-       large-parent-map
-       large-children-map
-       (filter #(not= large-unbalanced %))
-       first
-       (weight large-weight-map large-children-map)))
-
 (defn solve-2 []
-  (+ (large-weight-map large-unbalanced)
-     (- large-desired-tree-weight
-        (weight large-weight-map large-children-map large-unbalanced))))
+  (let [input              (read-input)
+        large-weight-map   (load-map input (juxt first second))
+        large-children-map (load-map input (juxt first last))
+        large-unbalanced   (unbalanced large-weight-map large-children-map (root-name))
+        large-parent-map   (lines-to-children-map input)
+        large-desired-tree (->> large-unbalanced
+                                large-parent-map
+                                large-children-map
+                                (filter #(not= large-unbalanced %))
+                                first
+                                (weight large-weight-map large-children-map))]
+    (+ (large-weight-map large-unbalanced)
+       (- large-desired-tree
+          (weight large-weight-map large-children-map large-unbalanced)))))
 
 (deftest part-1
   (is (= (str answer-1)

--- a/src/aoc/y2017/d07/dfuenzalida.cljc
+++ b/src/aoc/y2017/d07/dfuenzalida.cljc
@@ -1,0 +1,108 @@
+(ns aoc.y2017.d07.dfuenzalida
+  (:refer-clojure :exclude [read-string format])
+  (:require
+   [aoc.utils :as u :refer [deftest read-string format]]
+   [aoc.y2017.d07.data :refer [input answer-1 answer-2]]
+   [clojure.string :as s]
+   [clojure.test :as t :refer [is testing]]))
+
+(defn parents-in [[k vs]]
+  (reduce merge {}
+          (map #(hash-map % k) vs)))
+
+(defn parents-map [m]
+  (reduce merge (map parents-in m)))
+
+(defn parse-line [s]
+  (let [[_ parent weight] (first (re-seq #"(\w+) \((\d+)\)" s))
+        [_ s2]            (first (re-seq #".* -> (.*)" s))
+        children          (when s2 (s/split s2 #", "))]
+    [parent (read-string weight) children]))
+
+(defn lines-to-children-map [lines]
+  (->> lines
+       (map parse-line)
+       (map (juxt first last)) ;; name and children
+       (filter last)           ;; leave only nodes with children
+       (into {})
+       parents-map))
+
+(defn find-root [lines]
+  (let [data-map (lines-to-children-map lines)]
+    (first
+     (filter #(nil? (data-map %))
+             (vals data-map)))))
+
+(defn read-input []
+  (s/split-lines input))
+
+(defn solve-1 []
+  (find-root (read-input)))
+
+(defn root-name []
+  (find-root (read-input)))
+
+(defn load-map [lines f]
+  (->> lines
+       (map parse-line)
+       (map f)
+       (filter last) ;; we don't want nil values in the hashmap
+       (into {})))
+
+(defn weight [weight-map children-map node]
+  (+ (weight-map node)
+     (reduce +
+             (map (partial weight weight-map children-map)
+                  (children-map node)))))
+
+(defn unbalanced [weight-map children-map node]
+  (if (<= (count (into #{} (map (partial weight weight-map children-map)
+                                (children-map node)))) 1)
+    node ;; the current node is not balanced, all children have same weight
+    
+    (let [unb-child (->> (map (juxt identity
+                                    (partial weight weight-map children-map))
+                              (children-map node))
+                         (group-by second)
+                         (filter #(= 1 (count (second %))))
+                         first second first first)]
+      (unbalanced weight-map children-map unb-child))))
+
+(def large-weight-map
+  (load-map (read-input) (juxt first second)))
+
+(def large-children-map
+  (load-map (read-input) (juxt first last)))
+
+(def large-unbalanced
+  (unbalanced large-weight-map large-children-map (root-name)))
+
+(def large-parent-map
+  (lines-to-children-map (read-input)))
+
+(def large-desired-tree-weight
+  (->> large-unbalanced
+       large-parent-map
+       large-children-map
+       (filter #(not= large-unbalanced %))
+       first
+       (weight large-weight-map large-children-map)))
+
+(defn solve-2 []
+  (+ (large-weight-map large-unbalanced)
+     (- large-desired-tree-weight
+        (weight large-weight-map large-children-map large-unbalanced))))
+
+(deftest part-1
+  (is (= (str answer-1)
+         (str (solve-1)))))
+
+(deftest part-2
+  (is (= (str answer-2)
+         (str (solve-2)))))
+
+;;;; Scratch
+
+(comment
+  (t/run-tests)
+)

--- a/src/aoc/y2017/d08/dfuenzalida.cljc
+++ b/src/aoc/y2017/d08/dfuenzalida.cljc
@@ -1,0 +1,57 @@
+(ns aoc.y2017.d08.dfuenzalida
+  (:refer-clojure :exclude [read-string format])
+  (:require
+   [aoc.utils :as u :refer [deftest read-string format]]
+   [aoc.y2017.d08.data :refer [input answer-1 answer-2]]
+   [clojure.string :as s]
+   [clojure.test :as t :refer [is testing]]))
+
+(defn parse-line [s]
+  (let [[reg op amt _ reg2 cmp cmp-val] (s/split s #" ")]
+    [reg op (read-string amt) reg2 cmp (read-string cmp-val)]))
+
+(def fns
+  {"inc" + "dec" - "<" < "<=" <= "==" = "!=" not= ">=" >= ">" >})
+
+(defn process [lines m]
+  (if (seq lines)
+    (let [[reg op amt reg2 cmp cmp-val] (parse-line (first lines))]
+      (if ((fns cmp) (get m reg2 0) cmp-val)
+        (recur (rest lines)
+               (assoc m reg ((fns op) (get m reg 0) amt)))
+        (recur (rest lines) m)))
+    m))
+
+(defn read-input []
+  (s/split-lines input))
+
+(defn solve-1 []
+  (apply max (vals (process (read-input) {}))))
+
+(defn process2 [lines m max-val]
+  (if (seq lines)
+    (let [[reg op amt reg2 cmp cmp-val] (parse-line (first lines))]
+      (if ((fns cmp) (get m reg2 0) cmp-val)
+        (let [new-val ((fns op) (get m reg 0) amt)]
+          (recur (rest lines)
+                 (assoc m reg new-val)
+                 (max new-val max-val)))
+        (recur (rest lines) m max-val)))
+    [m max-val]))
+
+(defn solve-2 []
+  (last (process2 (read-input) {} 0)))
+
+(deftest part-1
+  (is (= (str answer-1)
+         (str (solve-1)))))
+
+(deftest part-2
+  (is (= (str answer-2)
+         (str (solve-2)))))
+
+;;;; Scratch
+
+(comment
+  (t/run-tests)
+)

--- a/src/aoc/y2017/d09/dfuenzalida.cljc
+++ b/src/aoc/y2017/d09/dfuenzalida.cljc
@@ -1,0 +1,50 @@
+(ns aoc.y2017.d09.dfuenzalida
+  (:refer-clojure :exclude [read-string format])
+  (:require
+   [aoc.utils :as u :refer [deftest read-string format]]
+   [aoc.y2017.d09.data :refer [input answer-1 answer-2]]
+   [clojure.string :as s]
+   [clojure.test :as t :refer [is testing]]))
+
+(defn clean [s]
+  (-> s
+      (s/replace #"!." "")
+      (s/replace #"<.*?>" "")))
+
+(defn score [s nesting total]
+  (if (seq s)
+    (condp = (first s)
+      \{ (recur (rest s) (inc nesting) (+ total nesting))
+      \} (recur (rest s) (dec nesting) total)
+      (recur (rest s) nesting total))
+    total))
+
+(defn solve-1 []
+  (score (clean input) 1 0))
+
+(defn cancel [s]
+  (s/replace s #"!." ""))
+
+(defn garbage-size [s]
+  (let [garbage-seq (->> s cancel (re-seq #"<.*?>"))]
+    (-
+     (reduce +
+             (map count garbage-seq))
+     (* 2 (count garbage-seq)))))
+
+(defn solve-2 []
+  (garbage-size input))
+
+(deftest part-1
+  (is (= (str answer-1)
+         (str (solve-1)))))
+
+(deftest part-2
+  (is (= (str answer-2)
+         (str (solve-2)))))
+
+;;;; Scratch
+
+(comment
+  (t/run-tests)
+)

--- a/src/aoc/y2017/d10/dfuenzalida.cljc
+++ b/src/aoc/y2017/d10/dfuenzalida.cljc
@@ -1,0 +1,95 @@
+(ns aoc.y2017.d10.dfuenzalida
+  (:refer-clojure :exclude [read-string format])
+  (:require
+   [aoc.utils :as u :refer [deftest read-string format]]
+   [aoc.y2017.d10.data :refer [input answer-1 answer-2]]
+   [clojure.string :as s]
+   [clojure.test :as t :refer [is testing]]))
+
+(defn update-vec [v v2 offset i]
+  (if (seq v2)
+    (recur (assoc-in v [(mod (+ i offset) (count v))] (first v2))
+           (rest v2) offset (inc i))
+    v))
+
+(defn iter1 [elems lengths pos skip]
+  (if (seq lengths)
+    (let [fstlen (first lengths)
+          l      (count elems)
+          revd   (->> elems cycle (drop pos) (take fstlen) reverse vec)
+          uptd   (update-vec elems revd pos 0)]
+      (recur uptd
+             (rest lengths)
+             (mod (+ pos fstlen skip) l)
+             (inc skip)))
+    elems))
+
+(defn read-input []
+  (read-string (str "[" input "]")))
+
+(defn solve-1 []
+  (let [nums (iter1 (into [] (range 256)) (read-input) 0 0)]
+    (* (first nums) (second nums))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(defn ascii [c]
+  #?(:clj (int c)
+     :cljs (.charCodeAt c 0)))
+
+(defn str-to-len [s]
+  (into (mapv ascii s) [17, 31, 73, 47, 23]))
+
+(defn iter2 [elems lengths pos skip]
+  (if (seq lengths)
+    (let [fstlen (first lengths)
+          l      (count elems)
+          revd   (->> elems cycle (drop pos) (take fstlen) reverse vec)
+          uptd   (update-vec elems revd pos 0)]
+      (recur uptd
+             (rest lengths)
+             (mod (+ pos fstlen skip) l)
+             (inc skip)))
+    [elems pos skip]))
+
+(defn run-rounds [elems lengths]
+  (loop [e elems
+         p 0
+         s 0
+         rounds 64]
+    (if (pos? rounds)
+      (let [[e2 p2 s2] (iter2 e lengths p s)]
+        (recur e2 p2 s2 (dec rounds)))
+      e)))
+
+(defn dense-hash [xs]
+  (let [seqs (partition 16 xs)]
+    (map #(reduce bit-xor %) seqs)))
+
+(defn to-hex [n]
+  (str
+   (nth "0123456789abcdef" (int (/ n 16)))
+   (nth "0123456789abcdef" (rem n 16))))
+
+(defn knot-hash [s]
+  (let [lengths (str-to-len s)
+        elems   (run-rounds (into [] (range 256)) lengths)
+        densed  (dense-hash elems)]
+    (apply str (map to-hex densed))))
+
+(defn solve-2 []
+  (knot-hash input))
+
+(deftest part-1
+  (is (= (str answer-1)
+         (str (solve-1)))))
+
+(deftest part-2
+  (is (= (str answer-2)
+         (str (solve-2)))))
+
+;;;; Scratch
+
+(comment
+  (t/run-tests)
+)


### PR DESCRIPTION
I'm slowly solving the puzzles for 2018, so here's a chunk of solutions from 2017 in the meantime. Most of them perform decently, except day 05 part 2 which takes about 10 seconds but I'm too lazy to optimize :grin: 

Test output below (all 10):

```
=== Running clojure test aoc.y2017.d01.dfuenzalida  

Running tests in #{"src"}

Testing aoc.y2017.d01.dfuenzalida
part-2 took 7 msecs
part-1 took 5 msecs

Ran 2 tests containing 2 assertions.
0 failures, 0 errors.

=== Running cljs test aoc.y2017.d01.dfuenzalida  

Testing aoc.y2017.d01.dfuenzalida
part-1 took 59 msecs
part-2 took 52 msecs

Ran 2 tests containing 2 assertions.
0 failures, 0 errors.
=== Running clojure test aoc.y2017.d02.dfuenzalida  

Running tests in #{"src"}

Testing aoc.y2017.d02.dfuenzalida
part-2 took 19 msecs
part-1 took 4 msecs

Ran 2 tests containing 2 assertions.
0 failures, 0 errors.

=== Running cljs test aoc.y2017.d02.dfuenzalida  

Testing aoc.y2017.d02.dfuenzalida
part-1 took 11 msecs
part-2 took 15 msecs

Ran 2 tests containing 2 assertions.
0 failures, 0 errors.
=== Running clojure test aoc.y2017.d03.dfuenzalida  

Running tests in #{"src"}

Testing aoc.y2017.d03.dfuenzalida
part-2 took 9 msecs
part-1 took 726 msecs

Ran 2 tests containing 2 assertions.
0 failures, 0 errors.

=== Running cljs test aoc.y2017.d03.dfuenzalida  

Testing aoc.y2017.d03.dfuenzalida
part-1 took 2065 msecs
part-2 took 12 msecs

Ran 2 tests containing 2 assertions.
0 failures, 0 errors.
=== Running clojure test aoc.y2017.d04.dfuenzalida  

Running tests in #{"src"}

Testing aoc.y2017.d04.dfuenzalida
part-2 took 88 msecs
part-1 took 16 msecs

Ran 2 tests containing 2 assertions.
0 failures, 0 errors.

=== Running cljs test aoc.y2017.d04.dfuenzalida  

Testing aoc.y2017.d04.dfuenzalida
part-1 took 81 msecs
part-2 took 147 msecs

Ran 2 tests containing 2 assertions.
0 failures, 0 errors.
=== Running clojure test aoc.y2017.d05.dfuenzalida  

Running tests in #{"src"}

Testing aoc.y2017.d05.dfuenzalida
part-2 took 10350 msecs
part-1 took 285 msecs

Ran 2 tests containing 2 assertions.
0 failures, 0 errors.

=== Running cljs test aoc.y2017.d05.dfuenzalida  

Testing aoc.y2017.d05.dfuenzalida
part-1 took 541 msecs
part-2 took 23172 msecs

Ran 2 tests containing 2 assertions.
0 failures, 0 errors.
=== Running clojure test aoc.y2017.d06.dfuenzalida  

Running tests in #{"src"}

Testing aoc.y2017.d06.dfuenzalida
part-2 took 300 msecs
part-1 took 151 msecs

Ran 2 tests containing 2 assertions.
0 failures, 0 errors.

=== Running cljs test aoc.y2017.d06.dfuenzalida  

Testing aoc.y2017.d06.dfuenzalida
part-1 took 772 msecs
part-2 took 470 msecs

Ran 2 tests containing 2 assertions.
0 failures, 0 errors.
=== Running clojure test aoc.y2017.d07.dfuenzalida  

Running tests in #{"src"}

Testing aoc.y2017.d07.dfuenzalida
part-2 took 1 msecs
part-1 took 21 msecs

Ran 2 tests containing 2 assertions.
0 failures, 0 errors.

=== Running cljs test aoc.y2017.d07.dfuenzalida  

Testing aoc.y2017.d07.dfuenzalida
part-1 took 112 msecs
part-2 took 0 msecs

Ran 2 tests containing 2 assertions.
0 failures, 0 errors.
=== Running clojure test aoc.y2017.d08.dfuenzalida  

Running tests in #{"src"}

Testing aoc.y2017.d08.dfuenzalida
part-2 took 70 msecs
part-1 took 23 msecs

Ran 2 tests containing 2 assertions.
0 failures, 0 errors.

=== Running cljs test aoc.y2017.d08.dfuenzalida  

Testing aoc.y2017.d08.dfuenzalida
part-1 took 128 msecs
part-2 took 68 msecs

Ran 2 tests containing 2 assertions.
0 failures, 0 errors.
=== Running clojure test aoc.y2017.d09.dfuenzalida  

Running tests in #{"src"}

Testing aoc.y2017.d09.dfuenzalida
part-2 took 21 msecs
part-1 took 17 msecs

Ran 2 tests containing 2 assertions.
0 failures, 0 errors.

=== Running cljs test aoc.y2017.d09.dfuenzalida  

Testing aoc.y2017.d09.dfuenzalida
part-1 took 24 msecs
part-2 took 11 msecs

Ran 2 tests containing 2 assertions.
0 failures, 0 errors.
=== Running clojure test aoc.y2017.d10.dfuenzalida  

Running tests in #{"src"}

Testing aoc.y2017.d10.dfuenzalida
part-2 took 447 msecs
part-1 took 11 msecs

Ran 2 tests containing 2 assertions.
0 failures, 0 errors.

=== Running cljs test aoc.y2017.d10.dfuenzalida  

Testing aoc.y2017.d10.dfuenzalida
part-1 took 43 msecs
part-2 took 573 msecs

Ran 2 tests containing 2 assertions.
0 failures, 0 errors.
```